### PR TITLE
Arbitrary union folding

### DIFF
--- a/src/types/base.typ
+++ b/src/types/base.typ
@@ -424,9 +424,9 @@
           // Invariant: there are no duplicate output types in 'unsure-outputs'.
           // The only time we push to unsure-outputs is after this check fails,
           // so that is always true.
-          let output-index = unsure-outputs.position(output)
-          unsure-outputs.remove(output-index)
-          unsure-output-data.remove(output-index)
+          let output-index = unsure-outputs.position(t => t == output)
+          _ = unsure-outputs.remove(output-index)
+          _ = unsure-output-data.remove(output-index)
         } else if output != "never" and output not in ambiguous-outputs {
           if typeinfo.input == "any" and typeinfo.check == none or i + 1 == typeinfo.len() {
             // Any output types which didn't match earlier will always match
@@ -451,7 +451,7 @@
     // No conflicts found for those types
     let unambiguous-outputs = unsure-output-data
 
-    (outer, inner) => {
+    let func(outer, inner) = {
       let outer-id = typeid(outer)
       let inner-id = typeid(inner)
       let outer-output = unambiguous-outputs.find(((_, _, output)) => outer-id == output)
@@ -479,6 +479,12 @@
       } else {
         folder(outer, inner)
       }
+    }
+
+    if unambiguous-outputs == () {
+      none
+    } else {
+      func
     }
   }
 

--- a/src/types/base.typ
+++ b/src/types/base.typ
@@ -395,7 +395,6 @@
     // (unless, of course, there is no casting).
     // However, if there is only one typeinfo with a given output type, it is
     // not ambiguous and may fold.
-    let fold-outputs = typeinfos.enumerate().map(((i, t)) => (i, t.fold, t.output))
     let unsure-outputs = () // array of (output type)
     let unsure-output-data = () // array of ((i, fold, output))
     let ambiguous-outputs = () // array of (output type)

--- a/test/unit/types/combinators/union/test.typ
+++ b/test/unit/types/combinators/union/test.typ
@@ -42,3 +42,9 @@
 #assert.eq((types.union(array, stroke, length).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
 #assert.eq((types.union(array, stroke, length).fold)(3pt, 8em), 8em)
 #assert.eq((types.union(array, stroke, length).fold)((1, 2), 3pt + yellow), 3pt + yellow)
+
+#let non-empty-array = types.wrap(array, check: _ => x => x != ())
+#let non-empty-array-with-fold = types.wrap(array, check: _ => x => x != (), fold: _ => (a, b) => b + a)
+// TODO: maybe fine if the fold function is the same?...
+#assert.eq(types.union(array, non-empty-array).fold, none)
+#assert.eq(types.union(array, non-empty-array-with-fold).fold, none)

--- a/test/unit/types/combinators/union/test.typ
+++ b/test/unit/types/combinators/union/test.typ
@@ -21,8 +21,24 @@
 #assert.eq(default(types.union(color, 5, float)).first(), false)
 
 // Folding
-// Option
+#assert.eq((types.union(array, stroke).fold)((1,), (2,)), (1, 2))
+#assert.eq((types.union(array, stroke).fold)(3pt + yellow, stroke(blue)), 3pt + blue)
+#assert.eq((types.union(array, stroke).fold)(3pt + yellow, (1, 2)), (1, 2))
+#assert.eq((types.union(array, stroke).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
+#assert.eq((types.union(array, stroke).fold)((1, 2), 3pt + yellow), 3pt + yellow)
+
 #assert.eq((types.union(array, stroke).fold)((1,), (2,)), (1, 2))
 #assert.eq((types.union(array, stroke).fold)(3pt + yellow, stroke(blue)), 3pt + blue)
 #assert.eq((types.union(array, stroke).fold)(3pt + yellow, (1, 2)), (1, 2))
 #assert.eq((types.union(array, stroke).fold)((1, 2), 3pt + yellow), 3pt + yellow)
+
+#assert.eq((types.union(array, dictionary).fold)((1, 2), (1, 2)), (1, 2, 1, 2))
+#assert.eq((types.union(array, dictionary).fold)((a: 1, b: 2), (c: 1, b: 4)), (c: 1, b: 4))
+#assert.eq((types.union(dictionary, array).fold)((1, 2), (1, 2)), (1, 2, 1, 2))
+
+#assert.eq((types.union(array, stroke, length).fold)((1,), (2,)), (1, 2))
+#assert.eq((types.union(array, stroke, length).fold)(3pt + yellow, stroke(blue)), 3pt + blue)
+#assert.eq((types.union(array, stroke, length).fold)(3pt + yellow, (1, 2)), (1, 2))
+#assert.eq((types.union(array, stroke, length).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
+#assert.eq((types.union(array, stroke, length).fold)(3pt, 8em), 8em)
+#assert.eq((types.union(array, stroke, length).fold)((1, 2), 3pt + yellow), 3pt + yellow)

--- a/test/unit/types/combinators/union/test.typ
+++ b/test/unit/types/combinators/union/test.typ
@@ -27,10 +27,33 @@
 #assert.eq((types.union(array, stroke).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
 #assert.eq((types.union(array, stroke).fold)((1, 2), 3pt + yellow), 3pt + yellow)
 
-#assert.eq((types.union(array, stroke).fold)((1,), (2,)), (1, 2))
-#assert.eq((types.union(array, stroke).fold)(3pt + yellow, stroke(blue)), 3pt + blue)
-#assert.eq((types.union(array, stroke).fold)(3pt + yellow, (1, 2)), (1, 2))
-#assert.eq((types.union(array, stroke).fold)((1, 2), 3pt + yellow), 3pt + yellow)
+#assert.eq((types.union(stroke, array).fold)((1,), (2,)), (1, 2))
+#assert.eq((types.union(stroke, array).fold)(3pt + yellow, stroke(blue)), 3pt + blue)
+#assert.eq((types.union(stroke, array).fold)(3pt + yellow, (1, 2)), (1, 2))
+#assert.eq((types.union(stroke, array).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
+#assert.eq((types.union(stroke, array).fold)((1, 2), 3pt + yellow), 3pt + yellow)
+
+#assert.eq((types.union(none, stroke, array).fold)((1,), (2,)), (1, 2))
+#assert.eq((types.union(none, stroke, array).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
+#assert.eq((types.union(none, stroke, array).fold)((1, 2), 3pt + yellow), 3pt + yellow)
+#assert.eq((types.union(none, stroke, array).fold)(none, 3pt + yellow), 3pt + yellow)
+#assert.eq((types.union(none, stroke, array).fold)(none, (1, 2)), (1, 2))
+#assert.eq((types.union(none, stroke, array).fold)((1, 2), none), none)
+
+#assert.eq((types.union(auto, stroke, array).fold)((1,), (2,)), (1, 2))
+#assert.eq((types.union(auto, stroke, array).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
+#assert.eq((types.union(auto, stroke, array).fold)((1, 2), auto), auto)
+#assert.eq((types.union(auto, stroke, array).fold)(auto, (1, 2)), (1, 2))
+
+#assert.eq((types.option(types.union(stroke, array)).fold)((1,), (2,)), (1, 2))
+#assert.eq((types.option(types.union(stroke, array)).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
+#assert.eq((types.option(types.union(stroke, array)).fold)((1, 2), none), none)
+#assert.eq((types.option(types.union(stroke, array)).fold)(none, (1, 2)), (1, 2))
+
+#assert.eq((types.smart(types.union(stroke, array)).fold)((1,), (2,)), (1, 2))
+#assert.eq((types.smart(types.union(stroke, array)).fold)(stroke(3pt), stroke(yellow)), 3pt + yellow)
+#assert.eq((types.smart(types.union(stroke, array)).fold)((1, 2), auto), auto)
+#assert.eq((types.smart(types.union(stroke, array)).fold)(auto, (1, 2)), (1, 2))
 
 #assert.eq((types.union(array, dictionary).fold)((1, 2), (1, 2)), (1, 2, 1, 2))
 #assert.eq((types.union(array, dictionary).fold)((a: 1, b: 2), (c: 1, b: 4)), (c: 1, b: 4))

--- a/test/unit/types/combinators/union/test.typ
+++ b/test/unit/types/combinators/union/test.typ
@@ -19,3 +19,10 @@
 #assert.eq(cast(5, types.union(color, types.exact(float), content, length)), (false, "expected color, float, none, content, string, symbol or length, found integer"))
 
 #assert.eq(default(types.union(color, 5, float)).first(), false)
+
+// Folding
+// Option
+#assert.eq((types.union(array, stroke).fold)((1,), (2,)), (1, 2))
+#assert.eq((types.union(array, stroke).fold)(3pt + yellow, stroke(blue)), 3pt + blue)
+#assert.eq((types.union(array, stroke).fold)(3pt + yellow, (1, 2)), (1, 2))
+#assert.eq((types.union(array, stroke).fold)((1, 2), 3pt + yellow), 3pt + yellow)

--- a/test/unit/types/combinators/union/test.typ
+++ b/test/unit/types/combinators/union/test.typ
@@ -66,8 +66,20 @@
 #assert.eq((types.union(array, stroke, length).fold)(3pt, 8em), 8em)
 #assert.eq((types.union(array, stroke, length).fold)((1, 2), 3pt + yellow), 3pt + yellow)
 
+#assert.eq(types.union(array, types.any).fold, none)
+
 #let non-empty-array = types.wrap(array, check: _ => x => x != ())
 #let non-empty-array-with-fold = types.wrap(array, check: _ => x => x != (), fold: _ => (a, b) => b + a)
-// TODO: maybe fine if the fold function is the same?...
 #assert.eq(types.union(array, non-empty-array).fold, none)
 #assert.eq(types.union(array, non-empty-array-with-fold).fold, none)
+
+#let any-wrap = types.wrap(
+  int,
+  // check: _ => i => i > 0 and i < 4,
+  cast: _ => i => (1, "a", (), (:)).at(calc.rem(i, 4)),
+  output: ("any",),
+  fold: _ => (a, b) => panic("dont fold"),
+)
+
+// This should be ambiguous
+#assert.eq((types.union(any-wrap, array).fold), none)


### PR DESCRIPTION
Fixes #10

Supports folding with union types like `union(array, stroke)`: two arrays are merged, two strokes are merged, but an array and a stroke or a stroke and an array are not merged.
However, this is not possible if more than one type could match the received types for folding. So folding is also cancelled in that case.

(We may want to allow that if the fold functions are identical though.)

TODO:
- [ ] ~~Consider union with `any`~~ Let's think about that later