### PR TITLE
Add folding to dicts by default

### DIFF
--- a/src/types/base.typ
+++ b/src/types/base.typ
@@ -534,6 +534,12 @@
     base.default
   }
 
+  let fold = if "fold" in other-args {
+    other-args.fold
+  } else {
+    base.fold
+  }
+
   (
     ..base,
     type-kind: "collection",
@@ -543,6 +549,7 @@
     cast: cast,
     error: error,
     default: default,
+    fold: fold,
   )
 }
 
@@ -654,6 +661,36 @@
       }
     },
 
-    error: error
+    error: error,
+
+    fold: if param.fold == none {
+      base-type.fold
+    } else if param.fold == auto {
+      (outer, inner) => {
+        let combined = outer + inner
+
+        for (k, v) in outer {
+          if k in inner {
+            combined.at(k) = v + inner.at(k)
+          }
+        }
+
+        combined
+      }
+    } else if type(param.fold) == function {
+      (outer, inner) => {
+        let combined = outer + inner
+
+        for (k, v) in outer {
+          if k in inner {
+            combined.at(k) = (param.fold)(v, inner.at(k))
+          }
+        }
+
+        combined
+      }
+    } else {
+      assert(false, message: "elembic: types.dict: parameter didn't have a valid fold function")
+    }
   )
 }

--- a/src/types/native.typ
+++ b/src/types/native.typ
@@ -95,7 +95,23 @@
   data: array,
   default: ((),),
 
-  // Array fields are added together by default.
+  // Array fields are joined together by default:
+  // set(field: (1, 2)), set(field: (3, 4))
+  // => set(field: (1, 2, 3, 4))
+  fold: auto,
+)
+
+#let dict_ = (
+  ..native-base,
+  name: str(dictionary),
+  input: (dictionary,),
+  output: (dictionary,),
+  data: dictionary,
+  default: ((:),),
+
+  // Dictionary fields are joined together by default:
+  // set(field: (a: 12)), set(field: (b: 13))
+  // => set(field: (a: 12, b: 13))
   fold: auto,
 )
 
@@ -143,14 +159,6 @@
   output: (bool,),
   data: bool,
   default: (false,)
-)
-#let dict_ = (
-  ..native-base,
-  name: str(dictionary),
-  input: (dictionary,),
-  output: (dictionary,),
-  data: dictionary,
-  default: ((:),),
 )
 #let int_ = (
   ..native-base,

--- a/test/unit/types/collections/array/test.typ
+++ b/test/unit/types/collections/array/test.typ
@@ -23,3 +23,7 @@
 #assert.eq(cast(("abc", 50, 0), types.array(pos-if-int-or-any)), err("an element in an array of positive integer or any did not typecheck\n  hint: at position 2: expected positive integer, got 0"))
 
 #assert.eq(default(types.array(types.union(float, int, color))), (true, ()))
+
+// Folding:
+// (1, 2), (3, 4) => (1, 2, 3, 4)
+#assert.eq(types.array(int).fold, auto)

--- a/test/unit/types/collections/dict/test.typ
+++ b/test/unit/types/collections/dict/test.typ
@@ -23,3 +23,18 @@
 #assert.eq(cast((v0: "abc", v1: 50, v2: 0), types.dict(pos-if-int-or-any)), err("a value in a dictionary of positive integer or any did not typecheck\n  hint: at key \"v2\": expected positive integer, got 0"))
 
 #assert.eq(default(types.dict(types.union(float, int, color))), (true, (:)))
+
+// Folding:
+#import types: dict
+#assert.eq(dict(int).fold, auto)
+#assert.eq(
+  (dict(array).fold)((a: (1, 2), b: (), c: (5,)), (a: (3, 4), b: (45,), d: (8, 8, 8))),
+  (a: (1, 2, 3, 4), b: (45,), c: (5,), d: (8, 8, 8))
+)
+#assert.eq(
+  (dict(stroke).fold)(
+    (a: stroke(red), b: 4pt + blue, c: 5pt + purple, e: 6pt + green),
+    (a: stroke(8em), b: stroke(10pt), d: stroke(orange), e: 10pt + blue)
+  ),
+  (a: 8em + red, b: 10pt + blue, c: 5pt + purple, d: stroke(orange), e: 10pt + blue)
+)

--- a/test/unit/types/combinators/union/test.typ
+++ b/test/unit/types/combinators/union/test.typ
@@ -56,7 +56,8 @@
 #assert.eq((types.smart(types.union(stroke, array)).fold)(auto, (1, 2)), (1, 2))
 
 #assert.eq((types.union(array, dictionary).fold)((1, 2), (1, 2)), (1, 2, 1, 2))
-#assert.eq((types.union(array, dictionary).fold)((a: 1, b: 2), (c: 1, b: 4)), (c: 1, b: 4))
+#assert.eq((types.union(array, dictionary).fold)((a: 1, b: 2), (c: 1, b: 4)), (a: 1, b: 4, c: 1))
+#assert.eq((types.union(array, dictionary).fold)((a: 1, b: 2), (1, 2)), (1, 2))
 #assert.eq((types.union(dictionary, array).fold)((1, 2), (1, 2)), (1, 2, 1, 2))
 
 #assert.eq((types.union(array, stroke, length).fold)((1,), (2,)), (1, 2))

--- a/test/unit/types/native/dictionary/test.typ
+++ b/test/unit/types/native/dictionary/test.typ
@@ -14,3 +14,5 @@
 
 #assert.eq(validate((a: 5)).first(), false)
 #assert.eq(default(native.dict_), (true, (:)))
+
+#assert.eq(native.dict_.fold, auto)


### PR DESCRIPTION
Two set rules on a dict field will now merge them unless disabled with `fold: false`.