### PR TITLE
Rewrite thesis template

### DIFF
--- a/examples/simple-thesis-template/main.typ
+++ b/examples/simple-thesis-template/main.typ
@@ -1,16 +1,12 @@
 #import "template.typ" as thesis: e
 
+#set page(paper: "a6")
+
 // Configure template
-#show: e.set_(
-  thesis.settings,
-  title: "Cool template",
-  author: "Kate",
-  advisor: "Robert",
-  coadvisors: ("John", "Ana"),
-)
+#show: e.set_(thesis.global-settings, primary-color: red.darken(20%))
 
 // Have a red background in the title page
-#show: e.set_(thesis.title-page, page-fill: red.lighten(50%))
+#show: e.set_(thesis.title-page, page-fill: purple.lighten(90%))
 
 // Override the bold text set rule
 #show e.selector(thesis.title-page, outer: true): set text(weight: "regular")
@@ -19,8 +15,18 @@
 #show: e.show_(thesis.title-page, emph)
 
 // Apply the template
-#show: thesis.template
+#show: thesis.template.with(
+  title: "My Awesome Thesis",
+  author: "Kate",
+  // These fields are optional
+  advisor: "Robert",
+  co-advisors: (
+    "John",
+    "Ana",
+  ),
+)
 
 = Introduction
 
+The _first_ paragraph.
 #lorem(80)


### PR DESCRIPTION
I have tried to re-write the thesis template to be more in line with the "proper" usage described in #67. Specifically, a thesis must have a title and an author and other fields are optional.

I don't know whether people should be encouraged to make templates this way or whether they should be encouraged to use an element as a bag of fields to be set. Please comment as to which approach is actually preferred :-)